### PR TITLE
Fix #20: long times break with Substack's Gamma

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ebisu-js",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "dist/ebisu.cjs",
   "module": "dist/ebisu.min.mjs",
   "types": "index.ts",
@@ -27,6 +27,6 @@
     "build-browser": "esbuild index.ts --bundle --minify  --sourcemap --platform=browser --format=iife --global-name=ebisu --outfile=dist/ebisu.min.js",
     "compile": "tsc -p .",
     "compile-watch": "tsc -p . --watch",
-    "test": "tape test.js"
+    "test": "npm run compile && tape test.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -44,3 +44,15 @@ test('compare', (t) => {
   }
   t.end();
 });
+
+// Fixes #20
+test("super-long t", (t) => {
+  ebisu.customizeMath(substackEbisu);
+  t.ok(ebisu.updateRecall([4, 4, 0.0607], 1, 1, 3.56))
+  t.ok(ebisu.updateRecall([4, 4, 0.24], 1, 1, 14.39))
+
+  t.ok(ebisu.updateRecall([4, 4, 1], 1, 1, 1_000))
+  t.ok(ebisu.updateRecall([4, 4, 1], 1, 1, 10_000))
+  t.ok(ebisu.updateRecall([4, 4, 1], 1, 1, 100_000))
+  t.end();
+});


### PR DESCRIPTION
For quizzes much longer than a model halflife, Substack's [Gamma](https://www.npmjs.com/package/gamma) can return NaNs during `_updateRecallSingle` 😭

(Note this doesn't happen with stdlib's more accurate Gamma function 💪!)

This PR fixes this by switching to the log domain if the default linear-domain calculation fails to converge. For the examples in #20, as well as much more extreme examples (per the new unit test, when the quiz is 1e5 times the halflife!), this is sufficient for the update step to converge.

New minor release version is included but needs to be rebuilt before release.